### PR TITLE
Add GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,66 @@
+name: Perl
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: [ubuntu-latest, macos-latest, windows-latest]
+        perl: [ '5.30', '5.36' ]
+        exclude:
+          - runner: windows-latest
+            perl: '5.36'
+
+    runs-on: ${{matrix.runner}}
+    name: OS ${{matrix.runner}} Perl ${{matrix.perl}}
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up perl
+      uses: shogo82148/actions-setup-perl@v1
+      with:
+          perl-version: ${{ matrix.perl }}
+          distribution: ${{ ( startsWith( matrix.runner, 'windows-' ) && 'strawberry' ) || 'default' }}
+
+    - name: Show Perl Version
+      run: |
+        perl -v
+
+    - name: Install Dist::Zilla
+      run: |
+        cpanm -v
+        cpanm --notest Dist::Zilla
+
+    - name: Install Modules
+      run: |
+        dzil authordeps --missing | cpanm --notest
+        dzil listdeps --missing | cpanm --notest
+
+    - name: Show Errors on Windows
+      if:  ${{ failure() && startsWith( matrix.runner, 'windows-')}}
+      run: |
+         ls -l C:/Users/
+         ls -l C:/Users/RUNNER~1/
+         cat C:/Users/runneradmin/.cpanm/work/*/build.log
+
+    - name: Show Errors on Ubuntu
+      if:  ${{ failure() && startsWith( matrix.runner, 'ubuntu-')}}
+      run: |
+         cat /home/runner/.cpanm/work/*/build.log
+
+    - name: Show Errors on OSX
+      if:  ${{ failure() && startsWith( matrix.runner, 'macos-')}}
+      run: |
+         cat  /Users/runner/.cpanm/work/*/build.log
+
+    - name: Run tests
+      run: |
+        dzil test
+
+ 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,9 @@ jobs:
     name: OS ${{matrix.runner}} Perl ${{matrix.perl}}
 
     steps:
+    - name: Git config
+      run: git config --global core.autocrlf false
+
     - uses: actions/checkout@v2
 
     - name: Set up perl

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
     - name: Install Modules
       run: |
         dzil authordeps --missing | cpanm --notest
-        dzil listdeps --missing | cpanm --notest
+        dzil listdeps --develop --missing | cpanm --notest
 
     - name: Show Errors on Windows
       if:  ${{ failure() && startsWith( matrix.runner, 'windows-')}}


### PR DESCRIPTION
Currently running on Windows fails. https://github.com/szabgab/Perl-Metrics-Halstead/actions/runs/3314492385/jobs/5473850019
I wonder if you'd like to fix that in the code in the test or just disable Windows. I left it in for now.

For more details about my quest to have CI for each Perl module:
https://perlmaven.com/os and https://perlmaven.com/ci
