### PR TITLE
use checkout v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Git config
       run: git config --global core.autocrlf false
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set up perl
       uses: shogo82148/actions-setup-perl@v1


### PR DESCRIPTION
to eliminate the NodeJs deprecation warning.